### PR TITLE
fix typos in views.py; remove app2 refernce urls.py

### DIFF
--- a/data/ShoeExpert/ShoeExpert/urls.py
+++ b/data/ShoeExpert/ShoeExpert/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from app1 import views as app1_views
-from app2 import views as app2_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/data/ShoeExpert/app1/views.py
+++ b/data/ShoeExpert/app1/views.py
@@ -5,5 +5,5 @@ from django.http import HttpResponse, HttpResponseRedirect
 def home(request):
     return render(request, 'app1/home.html')
 
-def about(request)
+def about(request):
     return render(request, 'app1/about.html')


### PR DESCRIPTION
Adds colon after function declaration -> app1/views.py

removes import of app2 -> ShoeExpert/urls.py
