### PR TITLE
Network Binds; Django Secrets; Simplify Container Creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ USER docker
 ENV PATH /home/docker/.local/bin:$PATH
 # Avoid first use of sudo warning. c.f. https://askubuntu.com/a/22614/781671
 RUN touch $HOME/.sudo_as_admin_successful
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip && \
 # Note: add any new PyPi packages to requirements.txt 
-RUN pip install -r .requirements.txt
+    pip install -r .requirements.txt && \
+    echo 'printf "SECRET_KEY='\''%s'\''\n" "$(python -c '\''from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'\'')" > /home/docker/.env' >> ~/.bashrc
+RUN echo 'sudo chown -R docker:root /home/docker/data && sudo chmod -R g+w /home/docker/data' >> /home/docker/.bashrc
 CMD [ "/bin/bash" ]

--- a/data/ShoeExpert/ShoeExpert/settings.py
+++ b/data/ShoeExpert/ShoeExpert/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 from pathlib import Path
 import os
+from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -23,7 +24,9 @@ STATIC_DIR = os.path.join(BASE_DIR, "static")
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ''
+dotenv_path = '/home/docker/.env'
+load_dotenv(dotenv_path)
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/data/ShoeExpert/ShoeExpert/urls.py
+++ b/data/ShoeExpert/ShoeExpert/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from app1 import views as app1_views
-from app2 import views as app2_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/data/ShoeExpert/app1/views.py
+++ b/data/ShoeExpert/app1/views.py
@@ -5,5 +5,5 @@ from django.http import HttpResponse, HttpResponseRedirect
 def home(request):
     return render(request, 'app1/home.html')
 
-def about(request)
+def about(request):
     return render(request, 'app1/about.html')

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,7 +153,7 @@ docker build -t shoe ${SHOE_ROOT}
 Create the container:
 
 ```bash
-docker run -dit --name shoe-container -v ${SHOE_ROOT}/data:/home/docker/data shoe
+docker run -dit -p 8000:8000/tcp --name shoe-container -v ${SHOE_ROOT}/data:/home/docker/data shoe
 ```
 
 Run the container:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -80,7 +80,7 @@ docker build -t shoe .
 
 This will use the Dockerfile to build an image tagged as `shoe`.
 
-## Creating the Container
+## Creating the Container (with Network Binding)
 
 In this step it is important to be in the root of the repo. Otherwise, the mounted directory will become misplaced on your native host. On my system, I've cloned the repo to `/home/mkapral/GitHub/Shoe-Expert`, but yours will be different. I recommend creating an environment variable and adding this to your shell's rc file for convenience.
 
@@ -94,6 +94,7 @@ Next, you can create the container with:
 
 ```bash
 docker run -dit \
+-p 8000:8000/tcp
 --name shoe-container \
 -v ${SHOE_ROOT}/data:/home/docker/data \
 shoe
@@ -102,8 +103,10 @@ shoe
 or as a one-liner:
 
 ```bash
-docker run -dit --name shoe-container -v ${SHOE_ROOT}/data:/home/docker/data shoe
+docker run -dit -p 8000:8000/tcp --name shoe-container -v ${SHOE_ROOT}/data:/home/docker/data shoe
 ```
+
+*The `-p` argument creates a network bind allowing tcp port 8000 to pass through to your native host. This is useful for when running `python manage.py runserver 0.0.0.0:8000`*
 
 *Only the contents within the `data` directory is shared between your native host and the container.*
 
@@ -116,27 +119,6 @@ To use it you need to exec into like so:
 ```bash
 docker exec -it shoe-container /bin/bash
 ```
-## Taking Ownership of `data` Directory (Only If Necessary)
-
-On some systems, it may be the case that the `data` directory is locked to the root user only.
-
-![png](png/dataPermissions.png)
-
-To change this, run (inside the container):
-
-```bash
-sudo chown -R docker:root data
-```
-
-This should only be necessary to execute once after creating container, not every time you `exec` into the container. On my macOS system, this was not necessary as permissions defaulted to `docker:docker`, and I assume that that will be the most common case. The reason for changing ownership to `docker:root` and not `docker:docker` if you experience this is because on your native host, the ownership id's will likely change to some garbage values:
-
-![png](png/garbageOwnership.png)
-
-By using `docker:root`, then at least you'll have access to the directory through group permissions when not inside the container:
-
-![png](png/semiGarbageOwnership.png)
-
-In any case, it will easiest to only modify the contents of `data` when inside the container.
 
 ## Stopping & Starting the Container
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django==4.1.7
-
+python-dotenv==0.21.1


### PR DESCRIPTION
**This PR depends on #21**

## Changelog
- Dockerfile updated to generate a new SECRET_KEY for your local dev environment every time you `docker exec` into it
- `settings.py` reads the `SECRET_KEY` environment variable
- dependency added in requirements.txt for `python-dotenv` for reading environment variable files
- Development Guide updated with an added argument in `docker run` for adding a network bind
- "Take Ownership..." section from Development Guide removed in favor of executing `chown` and `chmod` on every shell launch (`docker exec`)

Because of the changes to the `Dockerfile`, local containers should be purged and images updated upon merging.
