### PR TITLE
integrate bootstrap as django app

### DIFF
--- a/data/ShoeExpert/ShoeExpert/settings.py
+++ b/data/ShoeExpert/ShoeExpert/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'bootstrap4',
     'app1',
 ]
 

--- a/data/ShoeExpert/templates/app1/about.html
+++ b/data/ShoeExpert/templates/app1/about.html
@@ -1,10 +1,13 @@
 <html>
-	<head>
-		{% load static %}
-		{% include "app1/bootstrap.html" %}
-	</head>
-	<body>
-		{% include "app1/navigation.html" %}
-		<h1> Test about </h1>
-	</body>
+
+<head>
+	{% load static %}
+	{% include "app1/bootstrap.html" %}
+</head>
+
+<body>
+	{% include "app1/navigation.html" %}
+	<h1> Test about </h1>
+</body>
+
 </html>

--- a/data/ShoeExpert/templates/app1/bootstrap.html
+++ b/data/ShoeExpert/templates/app1/bootstrap.html
@@ -1,4 +1,5 @@
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384- Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous"/>
-<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384- J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384- Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384- wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+{% load bootstrap4 %}
+{% bootstrap_css %}
+{% bootstrap_javascript jquery='slim' %}
+{# Display django.contrib.messages as Bootstrap alerts #}
+{% bootstrap_messages %}

--- a/data/ShoeExpert/templates/app1/home.html
+++ b/data/ShoeExpert/templates/app1/home.html
@@ -1,10 +1,13 @@
 <html>
-	<head>
-		{% load static %}
-		{% include "app1/bootstrap.html" %}
-	</head>
-	<body>
-		{%include "app1/navigation.html" %}
-		<h1> Test: SHOE HOME </h1>
-	</body>
+
+<head>
+	{% load static %}
+	{% include "app1/bootstrap.html" %}
+</head>
+
+<body>
+	{%include "app1/navigation.html" %}
+	<h1> Test: SHOE HOME </h1>
+</body>
+
 </html>

--- a/data/ShoeExpert/templates/app1/navigation.html
+++ b/data/ShoeExpert/templates/app1/navigation.html
@@ -5,5 +5,5 @@
       <li class="nav-item">
         <a class="nav-link" href="/about"> About </a>
       </li>
-    </div>
-  </nav>
+  </div>
+</nav>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==4.1.7
 python-dotenv==1.0.0
+django-bootstrap4==22.3


### PR DESCRIPTION
- Bootstrap 4 is used to maintain compatiblity with c59f1ac
- Docs & Examples can be found [here](https://django-bootstrap4.readthedocs.io/en/latest/quickstart.html#demo-application)
- [django-bootstrap 4 GitHub](https://github.com/zostera/django-bootstrap4)
- [django-bootstrap 4 PyPI](https://pypi.org/project/django-bootstrap4/#description)

If we want to migrate to bootstrap 5 in the future, there is [this package](https://github.com/zelenij/django-bootstrap-v5)
However, the navbar did not like bootstrap5 when I tested it.
