### PR TITLE
Test Coverage Report

### DIFF
--- a/.scripts/runDjangoTests
+++ b/.scripts/runDjangoTests
@@ -6,8 +6,10 @@ if ! [ -f $PROC_SCHED ] || [ "$(awk 'FNR == 1 {print $1}' "$PROC_SCHED")" != "py
   exit 1
 fi
 
-if ! python /home/docker/data/ShoeExpert/manage.py test; then
+if ! coverage run --source="/home/docker/data/ShoeExpert" manage.py test app1; then
   exit 4
+elif ! coverage report; then
+  exit 5
 else
   exit 0
 fi

--- a/README.md
+++ b/README.md
@@ -26,3 +26,19 @@
 4. The container will automatically spawn a site running on port 8000 that you can access in the browser at [localhost:8000](http://127.0.0.1:8000)
 
 If you have a more complicated docker set-up, such as using docker in rootless mode, you can refer to the discussion in pr #28 or open up an issue in this repo if this workflow is not working correctly on your system.
+
+## Post Container Creation
+
+### Exit Codes
+
+0. Success
+
+1. Docker Container Not Detected (checks that python is PID 1)
+
+2. createDockerAdminUser script failed (could not create superuser docker)
+
+3. Failed to import shoe data from csv into postgres db
+
+4. Failed to execute tests
+
+5. Failed to generate coverage report

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-import-export==3.2.0
 selenium==4.9.1
 psycopg==3.1.9
 requests==2.30.0
+coverage==7.2.5


### PR DESCRIPTION
After running tests during the build process of the devcontainer, a coverage report is printed. This report along with the results of the unit tests are available in the container build logs. These are viewable in realtime by clicking the `show log` link in the bottom right when the devcontainer is being built in vscode.