### PR TITLE
McCabe Complexity Metrics for `views.py`

### DIFF
--- a/.scripts/runDjangoTests
+++ b/.scripts/runDjangoTests
@@ -10,6 +10,8 @@ if ! coverage run --source="/home/docker/data/ShoeExpert" manage.py test app1; t
   exit 4
 elif ! coverage report; then
   exit 5
+elif ! radon cc -s /home/docker/data/ShoeExpert/app1/views.py; then
+  exit 6
 else
   exit 0
 fi

--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ If you have a more complicated docker set-up, such as using docker in rootless m
 4. Failed to execute tests
 
 5. Failed to generate coverage report
+
+6. Failed to compute McCabe's Cyclomatic Complexity of Functions in `views.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ selenium==4.9.1
 psycopg==3.1.9
 requests==2.30.0
 coverage==7.2.5
+radon==6.0.1


### PR DESCRIPTION
Why only `views.py`?
The other django components are not easily analyzed due to their dynamic nature. E.g. `models.py` does not contain any models, rather it contains a function to generate all the shoe models for this project.

How to view metrics?
They appear in the logs on container build, similar to how tests and coverage are reported.